### PR TITLE
Add tutorials

### DIFF
--- a/docs/tutorials/blinky/blinky.rst
+++ b/docs/tutorials/blinky/blinky.rst
@@ -79,7 +79,7 @@ After you try the Blinky application on your boards, checkout out other
 tutorials to enable additional functionality such as :doc:`remote
 comms <../slinky/project-slinky>` on the current board. If you have BLE
 (Bluetooth Low Energy) chip (e.g. nRF52) on your board, you can try
-turning it into an :doc`iBeacon <../ble/ibeacon>` or :doc:`Eddystone
+turning it into an :doc:`iBeacon <../ble/ibeacon>` or :doc:`Eddystone
 Beacon <../ble/eddystone>`!
 
 If you see anything missing or want to send us feedback, please sign up

--- a/docs/tutorials/devmgmt/add_newtmgr.rst
+++ b/docs/tutorials/devmgmt/add_newtmgr.rst
@@ -8,7 +8,7 @@ application. This tutorial explains how to add the support to your
 application.
 
 This tutorial assumes that you have read the :doc:`Device Management with
-Newt Manager </os/modules/devmgmt/newtmgr/>`__ guide and are familiar
+Newt Manager <../../../os/modules/devmgmt/newtmgr>` guide and are familiar
 with the ``newtmgr`` and ``oicmgr`` frameworks and all the options that
 are available to customize your application.
 
@@ -18,8 +18,12 @@ This tutorial shows you how to configure your application to:
 -  Use serial transport to communicate with the newtmgr tool.
 -  Support all Newt Manager commands.
 
-See :doc:`Other Configuration Options <#other-configuration-options>`__ on
+See :doc:`Other Configuration Options <#other-configuration-options>` on
 how to customize your application.
+
+.. contents::
+   :local:
+   :depth: 2
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -31,8 +35,8 @@ with this tutorial:
 -  Have a cable to establish a serial USB connection between the board
    and the laptop.
 -  Install the newt tool and toolchains (See :doc:`Basic
-   Setup </os/get_started/get_started.md>`__).
--  Install the :doc:`newtmgr tool <../../newtmgr/install_mac.md>`__.
+   Setup <../../get_started/index>`).
+-  Install the :doc:`newtmgr tool <../../newtmgr/docs/install/index>`.
 
 Use an Existing Project
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,7 +119,7 @@ This example uses the Mynewt default event queue and you do not need to
 modify your application source.
 
 If you choose to use a different event queue, see :doc:`Events and Event
-Queues <event_queue.md>`__ for details on how to initialize an event
+Queues <../os_fundamentals/event_queue>` for details on how to initialize an event
 queue and create a task to process the events. You will also need to
 modify your ``main.c`` to add the call to the ``mgmt_evq_set()``
 function as follows:
@@ -182,7 +186,7 @@ Set Up a Connection Profile
 
 The newtmgr tool requires a connection profile in order to connect to
 your board. If you have not done so, follow the
-:doc:`instructions <../../newtmgr/command_list/newtmgr_conn.md>`__ for
+:doc:`instructions <../../newtmgr/command_list/newtmgr_conn>` for
 setting up your connection profile.
 
 Communicate with Your Application
@@ -252,12 +256,12 @@ modify the ``pkg.yml`` and ``syscfg.yml`` files as follows:
    ``pkg.deps`` parameter, and add ``SHELL_TASK: 1`` and
    ``SHELL_NEWTMGR`` to the ``syscfg.vals`` parameter to enable serial
    transport when your application also uses the
-   :doc:`Shell </os/modules/shell/shell.md>`__.
+   :doc:`Shell <../../../os/modules/shell/shell>`.
 -  Add the ``mgmt/newtmgr/transport/nmgr_uart`` package to the
    ``pkg.deps`` parameter to enable serial transport over a UART port.
    You can use this package instead of the ``nmgr_shell`` package when
    your application does not use the
-   :doc:`Shell </os/modules/shell/shell.md>`__ or you want to use a dedicated
+   :doc:`Shell <../../../os/modules/shell/shell>` or you want to use a dedicated
    UART port to communicate with newtmgr. You can change the
    ``NMGR_UART`` and ``NMGR_URART_SPEED`` sysconfig values to specify a
    different port.

--- a/docs/tutorials/devmgmt/add_newtmgr.rst
+++ b/docs/tutorials/devmgmt/add_newtmgr.rst
@@ -1,0 +1,315 @@
+Enabling Newt Manager in Your Application
+-----------------------------------------
+
+In order for your application to communicate with the newtmgr tool and
+process Newt Manager commands, you must enable Newt Manager device
+management and the support to process Newt Manager commands in your
+application. This tutorial explains how to add the support to your
+application.
+
+This tutorial assumes that you have read the :doc:`Device Management with
+Newt Manager </os/modules/devmgmt/newtmgr/>`__ guide and are familiar
+with the ``newtmgr`` and ``oicmgr`` frameworks and all the options that
+are available to customize your application.
+
+This tutorial shows you how to configure your application to:
+
+-  Use the newtmgr framework.
+-  Use serial transport to communicate with the newtmgr tool.
+-  Support all Newt Manager commands.
+
+See :doc:`Other Configuration Options <#other-configuration-options>`__ on
+how to customize your application.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+Ensure that you have met the following prerequisites before continuing
+with this tutorial:
+
+-  Have Internet connectivity to fetch remote Mynewt components.
+-  Have a cable to establish a serial USB connection between the board
+   and the laptop.
+-  Install the newt tool and toolchains (See :doc:`Basic
+   Setup </os/get_started/get_started.md>`__).
+-  Install the :doc:`newtmgr tool <../../newtmgr/install_mac.md>`__.
+
+Use an Existing Project
+~~~~~~~~~~~~~~~~~~~~~~~
+
+We assume that you have worked through at least some of the other
+tutorials and have an existing project. In this example, we modify the
+``btshell`` app to enable Newt Manager support. We call our target
+``myble``. You can create the target using any name you choose.
+
+Modify Package Dependencies and Configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add the following packages to the ``pkg.deps`` parameter in your target
+or application ``pkg.yml`` file:
+
+.. code-block:: console
+
+   pkg.deps:
+       - mgmt/newtmgr
+       - mgmt/newtmgr/transport/nmgr_shell
+       - mgmt/imgmgr
+       - sys/log/full
+       - sys/stats/full
+       - sys/config
+       - test/crash_test
+       - test/runtest
+
+Each package provides the following Newt Manager functionality:
+
+-  ``mgmt/newtmgr``: Supports the newtmgr framework and the Newt Manager
+   ``echo``, ``taskstat`` ``mpstat``, ``datetime``, and ``reset``
+   commands.
+-  ``mgmt/newtmgr/transport/nmgr_shell``: Supports serial transport.
+-  ``mgmt/imgmgr``: Supports the ``newtmgr image`` command
+-  ``sys/log/full`` : Supports the ``newtmgr log`` command.
+-  ``sys/stats/full``: Supports the ``newtmgr stat`` command.
+-  ``sys/config``: Supports the ``newtmgr config`` command.
+-  ``test/crash_test``: Supports the ``newtmgr crash`` command.
+-  ``test/runtest``: Supports the ``newt run`` command.
+
+Add the following configuration setting values to the ``syscfg.vals``
+parameter in the target or application ``syscfg.yml`` file:
+
+.. code-block:: console
+
+
+   syscfg.vals:
+       LOG_NEWTMGR: 1
+       STATS_NEWTMGR: 1
+       CONFIG_NEWTMGR: 1
+       CRASH_TEST_NEWTMGR: 1
+       RUNTEST_NEWTMGR: 1
+       SHELL_TASK: 1
+       SHELL_NEWTMGR: 1
+
+The first five configuration settings enable support for the Newt
+Manager ``log``, ``stat``, ``config``, ``crash``, and ``run`` commands.
+The ``SHELL_TASK`` setting enables the shell for serial transport. The
+``SHELL_NEWTMGR`` setting enables newtmgr support in the shell.
+
+Note that you may need to override additional configuration settings
+that are specific to each package to customize the package
+functionality.
+
+Modify the Source
+~~~~~~~~~~~~~~~~~
+
+By default, the ``mgmt`` package uses the Mynewt default event queue to
+receive request events from the newtmgr tool. These events are processed
+in the context of the application main task.
+
+You can specify a different event queue for the package to use. If you
+choose to use a dedicated event queue, you must create a task to process
+events from this event queue. The ``mgmt`` package executes and handles
+newtmgr request events in the context of this task. The ``mgmt`` package
+exports the ``mgmt_evq_set()`` function that allows you to specify an
+event queue.
+
+This example uses the Mynewt default event queue and you do not need to
+modify your application source.
+
+If you choose to use a different event queue, see :doc:`Events and Event
+Queues <event_queue.md>`__ for details on how to initialize an event
+queue and create a task to process the events. You will also need to
+modify your ``main.c`` to add the call to the ``mgmt_evq_set()``
+function as follows:
+
+Add the ``mgmt/mgmt.h`` header file:
+
+.. code-block:: c
+
+   #include <mgmt/mgmt.h>
+
+Add the call to specify the event queue. In the ``main()`` function,
+scroll down to the ``while (1)`` loop and add the following statement
+above the loop:
+
+.. code-block:: c
+
+   mgmt_evq_set(&my_eventq)
+
+where ``my_eventq`` is an event queue that you have initialized.
+
+Build the Targets
+~~~~~~~~~~~~~~~~~
+
+Build the two targets as follows:
+
+.. code-block:: console
+
+   $ newt build nrf52_boot
+   <snip>
+   App successfully built: ./bin/nrf52_boot/apps/boot/boot.elf
+   $ newt build myble
+   Compiling hci_common.c
+   Compiling util.c
+   Archiving nimble.a
+   Compiling os.c
+   <snip>
+
+Create the Application Image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Generate an application image for the ``myble`` target. You can use any
+version number you choose.
+
+.. code-block:: console
+
+   $ newt create-image myble 1.0.0
+   App image successfully generated: ./bin/makerbeacon/apps/btshell/btshell.img
+   Build manifest: ./bin/makerbeacon/apps/btshell/manifest.json
+
+Load the Image
+~~~~~~~~~~~~~~
+
+Ensure the USB connector is in place and the power LED on the board is
+lit. Turn the power switch on your board off, then back on to reset the
+board after loading the image.
+
+.. code-block:: console
+
+   $ newt load nrf52_boot
+   $ newt load myble
+
+Set Up a Connection Profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The newtmgr tool requires a connection profile in order to connect to
+your board. If you have not done so, follow the
+:doc:`instructions <../../newtmgr/command_list/newtmgr_conn.md>`__ for
+setting up your connection profile.
+
+Communicate with Your Application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once you have a connection profile set up, you can connect to your
+device with ``newtmgr -c myconn <command>`` to run commands in your
+application.
+
+Issue the ``echo`` command to ensure that your application is
+communicating with the newtmgr tool:
+
+.. code-block:: console
+
+   $ newtmgr -c myconn echo hello
+   hello
+
+ Test your application to ensure that it can process a Newt Manager
+command that is supported by a different package. Issue the ``stat``
+command to see the BLE stats.
+
+.. code-block:: console
+
+   stat group: ble_att
+            0 error_rsp_rx
+            0 error_rsp_tx
+            0 exec_write_req_rx
+            0 exec_write_req_tx
+            0 exec_write_rsp_rx
+            0 exec_write_rsp_tx
+            0 find_info_req_rx
+            0 find_info_req_tx
+            0 find_info_rsp_rx
+            0 find_info_rsp_tx
+            0 find_type_value_req_rx
+
+                  ...
+
+            0 read_type_req_tx
+            0 read_type_rsp_rx
+            0 read_type_rsp_tx
+            0 write_cmd_rx
+            0 write_cmd_tx
+            0 write_req_rx
+            0 write_req_tx
+            0 write_rsp_rx
+            0 write_rsp_tx
+
+Your application is now able to communicate with the newtmgr tool.
+
+Other Configuration Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section explains how to customize your application to use other
+Newt Manager protocol options.
+
+Newtmgr Framework Transport Protocol Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The newtmgr framework currently supports BLE and serial transport
+protocols. To configure the transport protocols that are supported,
+modify the ``pkg.yml`` and ``syscfg.yml`` files as follows:
+
+-  Add the ``mgmt/newtmgr/transport/ble`` package to the ``pkg.deps``
+   parameter to enable BLE transport.
+-  Add the ``mgmt/newtmgr/transport/nmgr_shell`` package to the
+   ``pkg.deps`` parameter, and add ``SHELL_TASK: 1`` and
+   ``SHELL_NEWTMGR`` to the ``syscfg.vals`` parameter to enable serial
+   transport when your application also uses the
+   :doc:`Shell </os/modules/shell/shell.md>`__.
+-  Add the ``mgmt/newtmgr/transport/nmgr_uart`` package to the
+   ``pkg.deps`` parameter to enable serial transport over a UART port.
+   You can use this package instead of the ``nmgr_shell`` package when
+   your application does not use the
+   :doc:`Shell </os/modules/shell/shell.md>`__ or you want to use a dedicated
+   UART port to communicate with newtmgr. You can change the
+   ``NMGR_UART`` and ``NMGR_URART_SPEED`` sysconfig values to specify a
+   different port.
+
+Oicmgr Framework Options
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To use the oicmgr framework instead of the newtmgr framework, modify the
+``pkg.yml`` and ``syscfg.yml`` files as follows:
+
+-  Add the ``mgmt/oicmgr`` package (instead of the ``mgmt/newtmgr`` and
+   ``mgmt/newtmgr/transport`` packages as described previously) to the
+   ``pkg.deps`` parameter.
+-  Add ``OC_SERVER: 1`` to the ``syscfg.vals`` parameter.
+
+Oicmgr supports the IP, serial, and BLE transport protocols. To
+configure the transport protocols that are supported, set the
+configuration setting values in the ``syscfg.vals`` parameter as
+follows:
+
+-  Add ``OC_TRANSPORT_IP: 1`` to enable IP transport.
+-  Add ``OC_TRANSPORT_GATT: 1`` to enable BLE transport.
+-  Add ``OC_TRANSPORT_SERIAL: 1``, ``SHELL_TASK: 1``,
+   ``SHELL_NEWTMGR:1`` to enable serial transport.
+
+Customize the Newt Manager Commands that Your Application Supports
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We recommend that you only enable support for the Newt Manager commands
+that your application uses to reduce your application code size. To
+configure the commands that are supported, set the configuration setting
+values in the ``syscfg.vals`` parameter as follows:
+
+-  Add ``LOG_NEWTMGR: 1`` to enable support for the ``newtmgr log``
+   command.
+-  Add ``STATS_NEWTMGR: 1`` to enable support for the ``newtmgr stat``
+   command.
+-  Add ``CONFIG_NEWTMGR: 1`` to enable support for the
+   ``newtmgr config`` command.
+-  Add ``CRASH_TEST_NEWTMGR: 1`` to enable support for the
+   ``newtmgr crash`` command.
+-  Add ``RUNTEST_NEWTMGR: 1`` to enable support for the
+   ``newtmgr crash`` command.
+
+Notes:
+
+-  When you enable Newt Manager support, using either the newtmgr or
+   oicmgr framework, your application automatically supports the Newt
+   Manager ``echo``, ``taskstat``, ``mpstat``, ``datetime``, and
+   ``reset`` commands. These commands cannot be configured individually.
+-  The ``mgmt/imgmgr`` package does not provide a configuration setting
+   to enable or disable support for the ``newtmgr image`` command. Do
+   not specify the package in the ``pkg.deps`` parameter if your device
+   has limited flash memory and cannot support Over-The-Air (OTA)
+   firmware upgrades.

--- a/docs/tutorials/devmgmt/devmgmt.rst
+++ b/docs/tutorials/devmgmt/devmgmt.rst
@@ -1,0 +1,8 @@
+Remote Device Management
+========================
+
+.. toctree::
+   :maxdepth: 1
+
+   Enable Newt Manager in Any App <add_newtmgr>
+   Upgrade an Image Over-The-Air <ota_upgrade_nrf52>

--- a/docs/tutorials/devmgmt/ota_upgrade_nrf52.rst
+++ b/docs/tutorials/devmgmt/ota_upgrade_nrf52.rst
@@ -17,6 +17,10 @@ image management over BLE transport support in your application.
 **Note:** Over-the-air upgrade via newtmgr BLE transport is supported on
 Mac OS and Linux. It is not supported on Windows platforms.
 
+.. contents::
+   :local:
+   :depth: 2
+
 Prerequisites
 -------------
 
@@ -29,15 +33,14 @@ Ensure that you meet the following prerequisites:
 -  Have a Nordic nRF52-DK Development Kit - PCA 10040
 -  Install the :doc:`Segger JLINK software and documentation
    pack <https://www.segger.com/jlink-software.html>`.
--  Install the newt tool and toolchains (See :doc:`Basic
-   Setup </os/get_started/get_started.md>`).
--  Read the Mynewt OS :doc:`Concepts </os/get_started/vocabulary.md>`
+-  Install the newt tool and toolchains (See :doc:`Setup & Get Started <../../get_started/index>`).
+-  Read the Mynewt OS :doc:`Concepts <../../concepts>`
    section.
--  Read the :doc:`Bootloader </os/modules/bootloader/bootloader>`__ section
+-  Read the :doc:`Secure Bootloader <../../../os/modules/bootloader/bootloader>` section
    and understand the Mynewt bootloader concepts.
 -  Build and load the **bleprph** application on to an nRF52-DK board
    via a serial connection. See :doc:`BLE Peripheral
-   App </os/tutorials/bleprph/bleprph-app/>`__.
+   App <../ble/bleprph/bleprph>`.
 
 Reducing the Log Level
 ----------------------
@@ -69,7 +72,7 @@ device over BLE. Step 2: Upload the image to the secondary slot (slot 1)
 on the device. Step 3: Test the image. Step 4: Confirm and make the
 image permanent.
 
-See the :doc:`Bootloader </os/modules/bootloader/bootloader>`__ section for
+See the :doc:`Secure Bootloader <../../../os/modules/bootloader/bootloader>` section for
 more information on the bootloader, image slots, and boot states.
 
 Step 1: Creating a Newtmgr Connection Profile

--- a/docs/tutorials/devmgmt/ota_upgrade_nrf52.rst
+++ b/docs/tutorials/devmgmt/ota_upgrade_nrf52.rst
@@ -1,0 +1,243 @@
+Over-the-Air Image Upgrade
+==========================
+
+Mynewt OS supports over-the-air image upgrades. This tutorial shows you
+how to use the newtmgr tool to upgrade an image on a device over BLE
+communication.
+
+To support over-the-air image upgrade over BLE, a device must be running
+a Mynewt application that has newtmgr image management over BLE
+transport enabled. For this tutorial, we use the
+:doc:`bleprph </os/tutorials/bleprph/bleprph-app/>` application, which
+includes image management over BLE functionality, on an nRF52-DK board.
+If you prefer to use a different BLE application, see :doc:`Enable Newt
+Manager in any app </os/tutorials/add_newtmgr/>` to enable newtmgr
+image management over BLE transport support in your application.
+
+**Note:** Over-the-air upgrade via newtmgr BLE transport is supported on
+Mac OS and Linux. It is not supported on Windows platforms.
+
+Prerequisites
+-------------
+
+Ensure that you meet the following prerequisites:
+
+-  Have Internet connectivity to fetch remote Mynewt components.
+-  Have a computer that supports Bluetooth to communicate with the board
+   and to build a Mynewt application.
+-  Have a Micro-USB cable to connect the board and the computer.
+-  Have a Nordic nRF52-DK Development Kit - PCA 10040
+-  Install the :doc:`Segger JLINK software and documentation
+   pack <https://www.segger.com/jlink-software.html>`.
+-  Install the newt tool and toolchains (See :doc:`Basic
+   Setup </os/get_started/get_started.md>`).
+-  Read the Mynewt OS :doc:`Concepts </os/get_started/vocabulary.md>`
+   section.
+-  Read the :doc:`Bootloader </os/modules/bootloader/bootloader>`__ section
+   and understand the Mynewt bootloader concepts.
+-  Build and load the **bleprph** application on to an nRF52-DK board
+   via a serial connection. See :doc:`BLE Peripheral
+   App </os/tutorials/bleprph/bleprph-app/>`__.
+
+Reducing the Log Level
+----------------------
+
+You need to build your application with log level set to INFO or lower.
+The default log level for the **bleprph** app is set to DEBUG. The extra
+logging causes the communication to timeout. Perform the following to
+reduce the log level to INFO, build, and load the application.
+
+.. code-block:: console
+
+
+   $ newt target amend myperiph syscfg="LOG_LEVEL=1"
+   $ newt build myperiph
+   $ newt create-image myperiph 1.0.0
+   $ newt load myperiph
+
+Upgrading an Image on a Device
+------------------------------
+
+Once you have an application with
+newtmgr image management with BLE transport support running on a device,
+you can use the newtmgr tool to upgrade an image over-the-air.
+
+You must perform the following steps to upgrade an image:
+
+Step 1: Create a newtmgr connection profile to communicate with the
+device over BLE. Step 2: Upload the image to the secondary slot (slot 1)
+on the device. Step 3: Test the image. Step 4: Confirm and make the
+image permanent.
+
+See the :doc:`Bootloader </os/modules/bootloader/bootloader>`__ section for
+more information on the bootloader, image slots, and boot states.
+
+Step 1: Creating a Newtmgr Connection Profile
+--------------------------------------------- 
+
+The **bleprph** application sets and advertises ``nimble-bleprph`` as its bluetooth
+device address. Run the ``newtmgr conn add`` command to create a newtmgr
+connection profile that uses this peer address to communicate with the
+device over BLE:
+
+.. code-block:: console
+
+
+   $ newtmgr conn add mybleprph type=ble connstring="peer_name=nimble-bleprph"
+   Connection profile mybleprph successfully added
+
+Verify that the newtmgr tool can communicate with the device and check
+the image status on the device:
+
+.. code-block:: console
+
+
+   $ newtmgr image list -c mybleprph 
+   Images:
+    slot=0
+       version: 1.0.0
+       bootable: true
+       flags: active confirmed
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+   Split status: N/A (0)
+
+The device only has an image loaded on the primary slot (slot 0). It
+does not have an image loaded on the secondary slot (slot 1). 
+
+Step 2: Uploading an Image to the Device
+----------------------------------------
+
+We create an image with version 2.0.0 for the bleprph application from the ``myperiph`` target and
+upload the new image. You can upload a different image.
+
+.. code-block:: console
+
+   $ newt create-image myperiph 2.0.0
+   App image succesfully generated: ~/dev/myproj/bin/targets/myperiph/app/apps/bleprph/bleprph.img
+
+Run the ``newtmgr image upload`` command to upload the image:
+
+.. code-block:: console
+
+   $ newtmgr image upload -c mybleprph ~/dev/myproj/bin/targets/myperiph/app/apps/bleprph/bleprph.img
+   215
+   429
+   642
+   855
+   1068
+   1281
+
+   ...
+
+   125953
+   126164
+   126375
+   126586
+   126704
+   Done
+
+The numbers indicate the number of bytes that the newtmgr tool has
+uploaded.
+
+Verify that the image uploaded to the secondary slot on the device
+successfully:
+
+.. code-block:: console
+
+
+   $ newtmgr image list -c mybleprph
+   Images:
+    slot=0
+       version: 1.0.0
+       bootable: true
+       flags: active confirmed
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+    slot=1
+       version: 2.0.0
+       bootable: true
+       flags: 
+       hash: 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+   Split status: N/A (0)
+
+The device now has the uploaded image in the secondary slot (slot 1).
+
+Step 3: Testing the Image 
+-------------------------
+
+The image is uploaded to the secondary
+slot but is not yet active. You must run the ``newtmgr image test``
+command to set the image status to **pending** and reboot the device.
+When the device reboots, the bootloader copies this image to the primary
+slot and runs the image.
+
+.. code-block:: console
+
+   $ newtmgr image test -c mybleprph 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+   Images:
+    slot=0
+       version: 1.0.0
+       bootable: true
+       flags: active confirmed
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+    slot=1
+       version: 2.0.0
+       bootable: true
+       flags: pending
+       hash: 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+   Split status: N/A (0)
+
+The status of the image in the secondary slot is now set to **pending**.
+
+Power the device OFF and ON and run the ``newtmgr image list`` command
+to check the image status on the device after the reboot:
+
+.. code-block:: console
+
+
+   $ newtmgr image list -c mybleprph
+   Images:
+    slot=0
+       version: 2.0.0
+       bootable: true
+       flags: active
+       hash: 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+    slot=1
+       version: 1.0.0
+       bootable: true
+       flags: confirmed
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+   Split status: N/A (0)
+
+The uploaded image is now active and running in the primary slot. The
+image, however, is not confirmed. The confirmed image is in the
+secondary slot. On the next reboot, the bootloader reverts to using the
+confirmed image. It copies the confirmed image to the primary slot and
+runs the image when the device reboots. You need to confirm and make the
+uploaded image in the primary slot permanent. 
+
+Step 4: Confirming the Image
+----------------------------
+
+Run the ``newtmgr image confirm`` command to confirm and make the
+uploaded image permanent. Since the uploaded image is currently the
+active image, you can confirm the image setup without specifying the
+image hash value in the command:
+
+.. code-block:: console
+
+   $ newtmgr image confirm -c mybleprph 
+   Images:
+    slot=0
+       version: 2.0.0
+       bootable: true
+       flags: active confirmed
+       hash: 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+    slot=1
+       version: 1.0.0
+       bootable: true
+       flags: 
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+   Split status: N/A (0)
+
+The uploaded image is now the active and confirmed image. You have
+successfully upgraded an image over-the-air.

--- a/docs/tutorials/os_fundamentals/os_fundamentals.rst
+++ b/docs/tutorials/os_fundamentals/os_fundamentals.rst
@@ -1,3 +1,6 @@
+OS Fundamentals
+===============
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/tutorials/os_fundamentals/tasks_lesson.rst
+++ b/docs/tutorials/os_fundamentals/tasks_lesson.rst
@@ -9,17 +9,21 @@ encountered when building applications using Mynewt. Specifically, this
 lesson will cover tasks, simple multitasking, and priority management
 running on an Arduino M0 Pro.
 
+.. contents::
+   :local:
+   :depth: 1
+
 Prerequisites
 -------------
 
 Before starting, you should read about Mynewt in the
-:doc:`Introduction <http://mynewt.apache.org/os/introduction/>` section and
+:doc:`Introduction <../../index>` section and
 complete the
-:doc:`QuickStart <http://mynewt.apache.org/os/get_started/get_started/>`
+:doc:`QuickStart <../../get_started/index>`
 guide and the
-:doc:`Blinky <http://mynewt.apache.org/os/tutorials/arduino_zero/>`
+:doc:`Blinky <../blinky/arduino_zero>`
 tutorial. Furthermore, it may be helpful to take a peek at the :doc:`task
-documentation <http://mynewt.apache.org/os/core_os/task/task/>` for
+documentation <../../../os/core_os/task/task>` for
 additional insights.
 
 Equipment
@@ -38,7 +42,7 @@ Build Your Application
 To save time, we will simply modify the Blinky application. We’ll add
 the Task Management code to the Blinky application. Follow the :doc:`Arduino
 Zero Blinky
-tutorial <os/tutorials/arduino_zero/>` to
+tutorial <../blinky/arduino_zero>` to
 create a new project and build your bootloader and application. Finally,
 build and load the application to your Arduino to verify that everything
 is in order. Now let’s get started!
@@ -68,7 +72,7 @@ apps/blinky/src):
    struct os_task work_task;
 
 A task is represented by the
-:doc:`os_task <http://mynewt.apache.org/os/core_os/task/task/#data-structures>`
+:doc:`os_task <../../../core_os/task/task>`
 struct which will hold the task’s information (name, state, priority,
 etc.). A task is made up of two main elements, a task function (also
 known as a task handler) and a task stack.
@@ -142,8 +146,7 @@ that work is more important than blinking.
 Initialization
 ~~~~~~~~~~~~~~
 
-To initialize a new task we use
-:doc:`os_task_init() <http://mynewt.apache.org/os/core_os/task/os_task_init/>`
+To initialize a new task we use ``os_task_init()``
 which takes a number of arguments including our new task function,
 stack, and priority.
 
@@ -197,7 +200,7 @@ When GDB appears press C then Enter to continue and … *wait, why
 doesn’t our LED blink anymore?*
 
 Review
-++++++
+^^^^^^
 
 Before we run our new app, let’s review what we need in
 order to create a task. This is a general case for a new task called
@@ -312,7 +315,7 @@ The diagram below shows the different scheduling patterns we would
 expect when we set the ``work_task`` priority higher and lower than the
 ``main`` task priority.
 
-.. figure:: pics/task_lesson.png
+.. figure:: ../pics/task_lesson.png
    :alt: Task Scheduling
 
    Task Scheduling
@@ -322,5 +325,5 @@ In the second case where the ``main`` task has a higher priority,
 saving us idle time compared to the first case.
 
 **Note:** Defining the same priority for two tasks fires an assert in
-os_task_init() and must be avoided. Priority 127 is reserved for main
+``os_task_init()`` and must be avoided. Priority 127 is reserved for main
 task, 255 for idle task.

--- a/docs/tutorials/os_fundamentals/tasks_lesson.rst
+++ b/docs/tutorials/os_fundamentals/tasks_lesson.rst
@@ -1,0 +1,326 @@
+Tasks and Priority Management
+=============================
+
+**Target Platform: Arduino M0 Pro** (or legacy Arduino Zero or Zero Pro,
+but not Arduino M0)
+
+This lesson is designed to teach core OS concepts and strategies
+encountered when building applications using Mynewt. Specifically, this
+lesson will cover tasks, simple multitasking, and priority management
+running on an Arduino M0 Pro.
+
+Prerequisites
+-------------
+
+Before starting, you should read about Mynewt in the
+:doc:`Introduction <http://mynewt.apache.org/os/introduction/>` section and
+complete the
+:doc:`QuickStart <http://mynewt.apache.org/os/get_started/get_started/>`
+guide and the
+:doc:`Blinky <http://mynewt.apache.org/os/tutorials/arduino_zero/>`
+tutorial. Furthermore, it may be helpful to take a peek at the :doc:`task
+documentation <http://mynewt.apache.org/os/core_os/task/task/>` for
+additional insights.
+
+Equipment
+---------
+
+You will need the following equipment:
+
+-  Arduino M0 Pro (or legacy Arduino Zero or Zero Pro, but not Arduino
+   M0)
+-  Computer with Mynewt installed
+-  USB to Micro USB Cable
+
+Build Your Application
+----------------------
+
+To save time, we will simply modify the Blinky application. We’ll add
+the Task Management code to the Blinky application. Follow the :doc:`Arduino
+Zero Blinky
+tutorial <os/tutorials/arduino_zero/>` to
+create a new project and build your bootloader and application. Finally,
+build and load the application to your Arduino to verify that everything
+is in order. Now let’s get started!
+
+Default Main Task
+-----------------
+
+During Mynewt system startup, Mynewt creates a default main task and
+executes the application ``main()`` function in the context of this
+task. The main task priority defaults to 127 and can be configured with
+the ``OS_MAIN_TASK_PRIO`` system configuration setting.
+
+The blinky application only has the ``main`` task. The ``main()``
+function executes an infinite loop that toggles the led and sleeps for
+one second. 
+
+Create a New Task
+-----------------
+
+The purpose of this section is to give an introduction to the important
+aspects of tasks and how to properly initialize them. First, let’s
+define a second task called ``work_task`` in main.c (located in
+apps/blinky/src):
+
+.. code-block:: c
+
+   struct os_task work_task;
+
+A task is represented by the
+:doc:`os_task <http://mynewt.apache.org/os/core_os/task/task/#data-structures>`
+struct which will hold the task’s information (name, state, priority,
+etc.). A task is made up of two main elements, a task function (also
+known as a task handler) and a task stack.
+
+Next, let’s take a look at what is required to initialize our new task.
+
+Task Stack
+~~~~~~~~~~
+
+The task stack is an array of type ``os_stack_t`` which holds the
+program stack frames. Mynewt gives us the ability to set the stack size
+for a task giving the application developer room to optimize memory
+usage. Since we’re not short on memory, our ``work_stack`` is plenty
+large for the purpose of this lesson. Notice that the elements in our
+task stack are of type ``os_stack_t`` which are generally 32 bits,
+making our entire stack 1024 Bytes.
+
+.. code-block:: c
+
+     #define WORK_STACK_SIZE OS_STACK_ALIGN(256)
+
+Note: The ``OS_STACK_ALIGN`` macro is used to align the stack based on
+the hardware architecture.
+
+Task Function
+~~~~~~~~~~~~~
+
+A task function is essentially an infinite loop that waits for some
+“event” to wake it up. In general, the task function is where the
+majority of work is done by a task. Let’s write a task function for
+``work_task`` called ``work_task_handler()``:
+
+.. code-block:: c
+
+   void
+   work_task_handler(void *arg)
+   {
+       struct os_task *t;
+
+       g_led_pin = LED_BLINK_PIN;
+       hal_gpio_init_out(g_led_pin, 1);
+       
+       while (1) {
+           t = os_sched_get_current_task();
+           assert(t->t_func == work_task_handler);
+           /* Do work... */
+       }
+   }
+
+The task function is called when the task is initially put into the
+*running* state by the scheduler. We use an infinite loop to ensure that
+the task function never returns. Our assertion that the current task’s
+handler is the same as our task handler is for illustration purposes
+only and does not need to be in most task functions.
+
+Task Priority
+~~~~~~~~~~~~~
+
+As a preemptive, multitasking RTOS, Mynewt decides which tasks to run
+based on which has a higher priority; the highest priority being 0 and
+the lowest 255. Thus, before initializing our task, we must choose a
+priority defined as a macro variable.
+
+Let’s set the priority of ``work_task`` to 0, because everyone knows
+that work is more important than blinking.
+
+.. code-block:: c
+
+     #define WORK_TASK_PRIO (0)
+
+Initialization
+~~~~~~~~~~~~~~
+
+To initialize a new task we use
+:doc:`os_task_init() <http://mynewt.apache.org/os/core_os/task/os_task_init/>`
+which takes a number of arguments including our new task function,
+stack, and priority.
+
+Add the ``init_tasks()`` function to initialize ``work_task`` to keep
+our main function clean.
+
+.. code-block:: c
+
+   int
+   init_tasks(void)
+   {
+       /* … */
+       os_stack_t *work_stack;
+       work_stack = malloc(sizeof(os_stack_t)*WORK_STACK_SIZE);
+       
+       assert(work_stack);
+       os_task_init(&work_task, "work", work_task_handler, NULL,
+               WORK_TASK_PRIO, OS_WAIT_FOREVER, work_stack,
+               WORK_STACK_SIZE);
+
+       return 0;
+   }
+
+Add the call to ``init_tasks()`` in ``main()`` before the ``while``
+loop:
+
+.. code-block:: c
+
+
+   int
+   main(int argc, char **argv)
+   {
+
+           ...
+
+       /* Initialize the work task */
+       init_tasks();
+
+       while (1) {
+            ...
+       }
+   }
+
+ And that’s it! Now run your application using the newt run command.
+
+.. code-block:: console
+
+   $ newt run arduino_blinky 0.0.0
+
+When GDB appears press C then Enter to continue and … *wait, why
+doesn’t our LED blink anymore?*
+
+Review
+++++++
+
+Before we run our new app, let’s review what we need in
+order to create a task. This is a general case for a new task called
+mytask:
+
+**1)** Define a new task, task stack, and priority:
+
+.. code-block:: c
+
+   /* My Task */
+   struct os_task mytask
+   /* My Task Stack */
+   #define MYTASK_STACK_SIZE OS_STACK_ALIGN(256)
+   os_stack_t mytask_stack[MYTASK_STACK_SIZE];
+   /* My Task Priority */
+   #define MYTASK_PRIO (0)
+
+**2)** Define task function:
+
+.. code-block:: c
+
+   void 
+   mytask_handler(void *arg)
+   {
+     while (1) {
+         /* ... */
+     }
+   }
+
+**3)** Initialize the task:
+
+.. code-block:: c
+
+   os_task_init(&mytask, "mytask", mytask_handler, NULL, 
+               MYTASK_PRIO, OS_WAIT_FOREVER, mytask_stack,
+               MYTASK_STACK_SIZE);
+
+Task Priority, Preempting, and Context Switching
+------------------------------------------------
+
+A preemptive RTOS is one in which a higher priority task that is *ready
+to run* will preempt (i.e. take the place of) the lower priority task
+which is *running*. When a lower priority task is preempted by a higher
+priority task, the lower priority task’s context data (stack pointer,
+registers, etc.) is saved and the new task is switched in.
+
+In our example, ``work_task`` (priority 0) has a higher priority than
+the ``main`` task (priority 127). Since ``work_task`` is never put into
+a *sleep* state, it holds the processor focus on its context.
+
+Let’s give ``work_task`` a delay and some simulated work to keep it
+busy. The delay is measured in os ticks and the actual number of ticks
+per second is dependent on the board. We multiply ``OS_TICKS_PER_SEC``,
+which is defined in the MCU, by the number of seconds we wish to delay.
+
+.. code-block:: c
+
+   void
+   work_task_handler(void *arg)
+   {
+       struct os_task *t;
+
+       g_led_pin = LED_BLINK_PIN;
+       hal_gpio_init_out(g_led_pin, 1);
+
+       while (1) {
+           t = os_sched_get_current_t:ask();
+           assert(t->t_func == work_task_handler);
+           /* Do work... */
+           int i;
+           for(i = 0; i < 1000000; ++i) {
+               /* Simulate doing a noticeable amount of work */
+               hal_gpio_write(g_led_pin, 1);
+           }
+           os_time_delay(3 * OS_TICKS_PER_SEC);
+       }
+   }
+
+ In order to notice the LED changing, modify the time delay in
+``main()`` to blink at a higher frequency.
+
+.. code-block:: c
+
+   os_time_delay(OS_TICKS_PER_SEC/10);
+
+ Before we run the app, let’s predict the behavior. With the newest
+additions to ``work_task_handler()``, our first action will be to sleep
+for three seconds. This allows the ``main`` task, running ``main()``, to
+take over the CPU and blink to its heart’s content. After three seconds,
+``work_task`` will wake up and be made *ready to run*. This causes it to
+preempt the ``main`` task. The LED will then remain lit for a short
+period while ``work_task`` loops, then blink again for another three
+seconds while ``work_task`` sleeps.
+
+You should see that our prediction was correct!
+
+Priority Management Considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When projects grow in scope, from blinking LEDs into more sophisticated
+applications, the number of tasks needed increases alongside complexity.
+It remains important, then, that each of our tasks is capable of doing
+its work within a reasonable amount of time.
+
+Some tasks, such as the Shell task, execute quickly and require almost
+instantaneous response. Therefore, the Shell task should be given a high
+priority. On the other hand, tasks which may be communicating over a
+network, or processing data, should be given a low priority in order to
+not hog the CPU.
+
+The diagram below shows the different scheduling patterns we would
+expect when we set the ``work_task`` priority higher and lower than the
+``main`` task priority.
+
+.. figure:: pics/task_lesson.png
+   :alt: Task Scheduling
+
+   Task Scheduling
+
+In the second case where the ``main`` task has a higher priority,
+``work_task`` runs and executes “work” when the ``main`` task sleeps,
+saving us idle time compared to the first case.
+
+**Note:** Defining the same priority for two tasks fires an assert in
+os_task_init() and must be avoided. Priority 127 is reserved for main
+task, 255 for idle task.

--- a/docs/tutorials/sensors/air_quality_sensor.rst
+++ b/docs/tutorials/sensors/air_quality_sensor.rst
@@ -8,7 +8,7 @@ This tutorial will show you how to set up and use the Senseair K30 air quality s
 
 Prerequisites
 ~~~~~~~~~~~~~
-- Complete one of the other tutorials (e.g. :doc:`Project Blinky <blinky>`) to famliarize yourself with Mynewt
+- Complete one of the other tutorials (e.g. :doc:`Project Blinky <../blinky/blinky>`) to famliarize yourself with Mynewt
 - Nordic nRF52 Development - PCA 10040
 - Senseair K30 CO2 Sensor
 
@@ -295,7 +295,7 @@ Add a call to your ``main()`` to initialize this driver:
 Add CLI Commands For Testing Drivers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While developing the driver, it would be helpful to issue operations from the console to verify the driver is responding correctly. Since the nRF52DK only has one UART, which will be used to connect to the CO2 sensor, the console we'll use instead is the :doc:`Segger RTT Console <segger_rtt>`. To configure this, make the following changes in your project's ``syscfg.yml`` file:
+While developing the driver, it would be helpful to issue operations from the console to verify the driver is responding correctly. Since the nRF52DK only has one UART, which will be used to connect to the CO2 sensor, the console we'll use instead is the :doc:`Segger RTT Console <../tooling/segger_rtt>`. To configure this, make the following changes in your project's ``syscfg.yml`` file:
 
 .. code-block:: console
 

--- a/docs/tutorials/sensors/nrf52_adc.rst
+++ b/docs/tutorials/sensors/nrf52_adc.rst
@@ -22,7 +22,7 @@ Required Hardware
 -  Laptop running Mac OS
 -  It is assumed you have already installed newt tool.
 -  It is assumed you already installed native tools as described
-   :doc:`here <../../get_started/native_tools>`
+   :doc:`here <../../get_started/native_install/native_tools>`
 
 Create a Project
 ----------------
@@ -817,7 +817,7 @@ device. That's no small feat!
 
 If you see anything missing or want to send us feedback, please do so by
 signing up for appropriate mailing lists on our :doc:`Community
-Page <community>`
+Page <community>`.
 
 Keep on hacking and sensing!
 

--- a/docs/tutorials/tutorials.rst
+++ b/docs/tutorials/tutorials.rst
@@ -12,6 +12,7 @@ Tutorials
    Bluetooth Low Energy <ble/ble>
    LoRa <lora/lorawanapp>
    OS Fundamentals <os_fundamentals/os_fundamentals>
+   Remote Device Management <devmgmt/devmgmt>
    Sensors <sensors/sensors>
    Tooling <tooling/tooling>
    Other <other/other>
@@ -84,8 +85,8 @@ category are listed below.
 
 -  Remote Device Management
 
-   -  :doc:`Enabling Newt Manager in Any App <../add_newtmgr>`
-   -  :doc:`Upgrading an Image Over-The-Air <ota_upgrade_nrf52>`
+   -  :doc:`Enabling Newt Manager in Any App <devmgmt/add_newtmgr>`
+   -  :doc:`Upgrading an Image Over-The-Air <devmgmt/ota_upgrade_nrf52>`
 
 -  Sensors
 


### PR DESCRIPTION
Added the following tutorials:
- Tasks and Priority Management
- Enabling Newt Manager in Any App
- Upgrading an Image Over-The-Air

Created a directory ../devmgmt to house the bottom two tutorials. 

Also updated links in other docs, and minor fixes.

FYI: the missing tutorials that are added (on top of others) are also in mynewt-core/docs/tutorials. Although they don't show up in the mynewt.apache.org documentation section, they do appear in search results. Including the tutorials in this repo will cause them to appear twice in searches, so getting rid of one copy (probably the one in mynewt-core?) is recommended.