### PR TITLE
LED blink pin note, FAQ update

### DIFF
--- a/docs/tutorials/blinky/blinky_primo.rst
+++ b/docs/tutorials/blinky/blinky_primo.rst
@@ -246,7 +246,7 @@ Run the ``newt load primoblinky`` command to load the Blinky application image o
 You should see the orange LED (L13), below the ON LED, on the board
 blink!
 
-**Note**: If the LED does not blink, try resetting the board. Otherwise, you may have an older version of the Arduino Primo, and will need to change the defined LED blink pin. To change the LED blink pin, go to the Arduino Primo BSP header file in the repos directory (``~/dev/myproj/repos/apache-mynewt-core/hw/bsp/arduino_primoo_nrf52/include/bsp/bsp.h``) and change the ``LED_BLINK_PIN`` from 20 to 25. 
+**Note**: If the LED does not blink, try resetting the board. If that doesn't work, you may have an older version of the Arduino Primo, and will need to change the defined LED blink pin. To change the LED blink pin, go to the Arduino Primo BSP header file in the repos directory (``~/dev/myproj/repos/apache-mynewt-core/hw/bsp/arduino_primoo_nrf52/include/bsp/bsp.h``) and change the ``LED_BLINK_PIN`` from 20 to 25. 
 
 Erase Flash
 ~~~~~~~~~~~

--- a/docs/tutorials/blinky/blinky_primo.rst
+++ b/docs/tutorials/blinky/blinky_primo.rst
@@ -246,7 +246,7 @@ Run the ``newt load primoblinky`` command to load the Blinky application image o
 You should see the orange LED (L13), below the ON LED, on the board
 blink!
 
-Note: If the LED does not blink, try resetting the board.
+**Note**: If the LED does not blink, try resetting the board. Otherwise, you may have an older version of the Arduino Primo, and will need to change the defined LED blink pin. To change the LED blink pin, go to the Arduino Primo BSP header file in the repos directory (``~/dev/myproj/repos/apache-mynewt-core/hw/bsp/arduino_primoo_nrf52/include/bsp/bsp.h``) and change the ``LED_BLINK_PIN`` from 20 to 25. 
 
 Erase Flash
 ~~~~~~~~~~~

--- a/docs/tutorials/devmgmt/add_newtmgr.rst
+++ b/docs/tutorials/devmgmt/add_newtmgr.rst
@@ -8,7 +8,7 @@ application. This tutorial explains how to add the support to your
 application.
 
 This tutorial assumes that you have read the :doc:`Device Management with
-Newt Manager </os/modules/devmgmt/newtmgr/>`__ guide and are familiar
+Newt Manager <../../../os/modules/devmgmt/newtmgr>` guide and are familiar
 with the ``newtmgr`` and ``oicmgr`` frameworks and all the options that
 are available to customize your application.
 
@@ -18,8 +18,12 @@ This tutorial shows you how to configure your application to:
 -  Use serial transport to communicate with the newtmgr tool.
 -  Support all Newt Manager commands.
 
-See :doc:`Other Configuration Options <#other-configuration-options>`__ on
+See :doc:`Other Configuration Options <#other-configuration-options>` on
 how to customize your application.
+
+.. contents::
+   :local:
+   :depth: 2
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -31,8 +35,8 @@ with this tutorial:
 -  Have a cable to establish a serial USB connection between the board
    and the laptop.
 -  Install the newt tool and toolchains (See :doc:`Basic
-   Setup </os/get_started/get_started.md>`__).
--  Install the :doc:`newtmgr tool <../../newtmgr/install_mac.md>`__.
+   Setup <../../get_started/index>`).
+-  Install the :doc:`newtmgr tool <../../newtmgr/docs/install/index>`.
 
 Use an Existing Project
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,7 +119,7 @@ This example uses the Mynewt default event queue and you do not need to
 modify your application source.
 
 If you choose to use a different event queue, see :doc:`Events and Event
-Queues <event_queue.md>`__ for details on how to initialize an event
+Queues <../os_fundamentals/event_queue>` for details on how to initialize an event
 queue and create a task to process the events. You will also need to
 modify your ``main.c`` to add the call to the ``mgmt_evq_set()``
 function as follows:
@@ -182,7 +186,7 @@ Set Up a Connection Profile
 
 The newtmgr tool requires a connection profile in order to connect to
 your board. If you have not done so, follow the
-:doc:`instructions <../../newtmgr/command_list/newtmgr_conn.md>`__ for
+:doc:`instructions <../../newtmgr/command_list/newtmgr_conn>` for
 setting up your connection profile.
 
 Communicate with Your Application
@@ -252,12 +256,12 @@ modify the ``pkg.yml`` and ``syscfg.yml`` files as follows:
    ``pkg.deps`` parameter, and add ``SHELL_TASK: 1`` and
    ``SHELL_NEWTMGR`` to the ``syscfg.vals`` parameter to enable serial
    transport when your application also uses the
-   :doc:`Shell </os/modules/shell/shell.md>`__.
+   :doc:`Shell <../../../os/modules/shell/shell>`.
 -  Add the ``mgmt/newtmgr/transport/nmgr_uart`` package to the
    ``pkg.deps`` parameter to enable serial transport over a UART port.
    You can use this package instead of the ``nmgr_shell`` package when
    your application does not use the
-   :doc:`Shell </os/modules/shell/shell.md>`__ or you want to use a dedicated
+   :doc:`Shell <../../../os/modules/shell/shell>` or you want to use a dedicated
    UART port to communicate with newtmgr. You can change the
    ``NMGR_UART`` and ``NMGR_URART_SPEED`` sysconfig values to specify a
    different port.

--- a/docs/tutorials/devmgmt/add_newtmgr.rst
+++ b/docs/tutorials/devmgmt/add_newtmgr.rst
@@ -1,0 +1,315 @@
+Enabling Newt Manager in Your Application
+-----------------------------------------
+
+In order for your application to communicate with the newtmgr tool and
+process Newt Manager commands, you must enable Newt Manager device
+management and the support to process Newt Manager commands in your
+application. This tutorial explains how to add the support to your
+application.
+
+This tutorial assumes that you have read the :doc:`Device Management with
+Newt Manager </os/modules/devmgmt/newtmgr/>`__ guide and are familiar
+with the ``newtmgr`` and ``oicmgr`` frameworks and all the options that
+are available to customize your application.
+
+This tutorial shows you how to configure your application to:
+
+-  Use the newtmgr framework.
+-  Use serial transport to communicate with the newtmgr tool.
+-  Support all Newt Manager commands.
+
+See :doc:`Other Configuration Options <#other-configuration-options>`__ on
+how to customize your application.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+Ensure that you have met the following prerequisites before continuing
+with this tutorial:
+
+-  Have Internet connectivity to fetch remote Mynewt components.
+-  Have a cable to establish a serial USB connection between the board
+   and the laptop.
+-  Install the newt tool and toolchains (See :doc:`Basic
+   Setup </os/get_started/get_started.md>`__).
+-  Install the :doc:`newtmgr tool <../../newtmgr/install_mac.md>`__.
+
+Use an Existing Project
+~~~~~~~~~~~~~~~~~~~~~~~
+
+We assume that you have worked through at least some of the other
+tutorials and have an existing project. In this example, we modify the
+``btshell`` app to enable Newt Manager support. We call our target
+``myble``. You can create the target using any name you choose.
+
+Modify Package Dependencies and Configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add the following packages to the ``pkg.deps`` parameter in your target
+or application ``pkg.yml`` file:
+
+.. code-block:: console
+
+   pkg.deps:
+       - mgmt/newtmgr
+       - mgmt/newtmgr/transport/nmgr_shell
+       - mgmt/imgmgr
+       - sys/log/full
+       - sys/stats/full
+       - sys/config
+       - test/crash_test
+       - test/runtest
+
+Each package provides the following Newt Manager functionality:
+
+-  ``mgmt/newtmgr``: Supports the newtmgr framework and the Newt Manager
+   ``echo``, ``taskstat`` ``mpstat``, ``datetime``, and ``reset``
+   commands.
+-  ``mgmt/newtmgr/transport/nmgr_shell``: Supports serial transport.
+-  ``mgmt/imgmgr``: Supports the ``newtmgr image`` command
+-  ``sys/log/full`` : Supports the ``newtmgr log`` command.
+-  ``sys/stats/full``: Supports the ``newtmgr stat`` command.
+-  ``sys/config``: Supports the ``newtmgr config`` command.
+-  ``test/crash_test``: Supports the ``newtmgr crash`` command.
+-  ``test/runtest``: Supports the ``newt run`` command.
+
+Add the following configuration setting values to the ``syscfg.vals``
+parameter in the target or application ``syscfg.yml`` file:
+
+.. code-block:: console
+
+
+   syscfg.vals:
+       LOG_NEWTMGR: 1
+       STATS_NEWTMGR: 1
+       CONFIG_NEWTMGR: 1
+       CRASH_TEST_NEWTMGR: 1
+       RUNTEST_NEWTMGR: 1
+       SHELL_TASK: 1
+       SHELL_NEWTMGR: 1
+
+The first five configuration settings enable support for the Newt
+Manager ``log``, ``stat``, ``config``, ``crash``, and ``run`` commands.
+The ``SHELL_TASK`` setting enables the shell for serial transport. The
+``SHELL_NEWTMGR`` setting enables newtmgr support in the shell.
+
+Note that you may need to override additional configuration settings
+that are specific to each package to customize the package
+functionality.
+
+Modify the Source
+~~~~~~~~~~~~~~~~~
+
+By default, the ``mgmt`` package uses the Mynewt default event queue to
+receive request events from the newtmgr tool. These events are processed
+in the context of the application main task.
+
+You can specify a different event queue for the package to use. If you
+choose to use a dedicated event queue, you must create a task to process
+events from this event queue. The ``mgmt`` package executes and handles
+newtmgr request events in the context of this task. The ``mgmt`` package
+exports the ``mgmt_evq_set()`` function that allows you to specify an
+event queue.
+
+This example uses the Mynewt default event queue and you do not need to
+modify your application source.
+
+If you choose to use a different event queue, see :doc:`Events and Event
+Queues <event_queue.md>`__ for details on how to initialize an event
+queue and create a task to process the events. You will also need to
+modify your ``main.c`` to add the call to the ``mgmt_evq_set()``
+function as follows:
+
+Add the ``mgmt/mgmt.h`` header file:
+
+.. code-block:: c
+
+   #include <mgmt/mgmt.h>
+
+Add the call to specify the event queue. In the ``main()`` function,
+scroll down to the ``while (1)`` loop and add the following statement
+above the loop:
+
+.. code-block:: c
+
+   mgmt_evq_set(&my_eventq)
+
+where ``my_eventq`` is an event queue that you have initialized.
+
+Build the Targets
+~~~~~~~~~~~~~~~~~
+
+Build the two targets as follows:
+
+.. code-block:: console
+
+   $ newt build nrf52_boot
+   <snip>
+   App successfully built: ./bin/nrf52_boot/apps/boot/boot.elf
+   $ newt build myble
+   Compiling hci_common.c
+   Compiling util.c
+   Archiving nimble.a
+   Compiling os.c
+   <snip>
+
+Create the Application Image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Generate an application image for the ``myble`` target. You can use any
+version number you choose.
+
+.. code-block:: console
+
+   $ newt create-image myble 1.0.0
+   App image successfully generated: ./bin/makerbeacon/apps/btshell/btshell.img
+   Build manifest: ./bin/makerbeacon/apps/btshell/manifest.json
+
+Load the Image
+~~~~~~~~~~~~~~
+
+Ensure the USB connector is in place and the power LED on the board is
+lit. Turn the power switch on your board off, then back on to reset the
+board after loading the image.
+
+.. code-block:: console
+
+   $ newt load nrf52_boot
+   $ newt load myble
+
+Set Up a Connection Profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The newtmgr tool requires a connection profile in order to connect to
+your board. If you have not done so, follow the
+:doc:`instructions <../../newtmgr/command_list/newtmgr_conn.md>`__ for
+setting up your connection profile.
+
+Communicate with Your Application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once you have a connection profile set up, you can connect to your
+device with ``newtmgr -c myconn <command>`` to run commands in your
+application.
+
+Issue the ``echo`` command to ensure that your application is
+communicating with the newtmgr tool:
+
+.. code-block:: console
+
+   $ newtmgr -c myconn echo hello
+   hello
+
+ Test your application to ensure that it can process a Newt Manager
+command that is supported by a different package. Issue the ``stat``
+command to see the BLE stats.
+
+.. code-block:: console
+
+   stat group: ble_att
+            0 error_rsp_rx
+            0 error_rsp_tx
+            0 exec_write_req_rx
+            0 exec_write_req_tx
+            0 exec_write_rsp_rx
+            0 exec_write_rsp_tx
+            0 find_info_req_rx
+            0 find_info_req_tx
+            0 find_info_rsp_rx
+            0 find_info_rsp_tx
+            0 find_type_value_req_rx
+
+                  ...
+
+            0 read_type_req_tx
+            0 read_type_rsp_rx
+            0 read_type_rsp_tx
+            0 write_cmd_rx
+            0 write_cmd_tx
+            0 write_req_rx
+            0 write_req_tx
+            0 write_rsp_rx
+            0 write_rsp_tx
+
+Your application is now able to communicate with the newtmgr tool.
+
+Other Configuration Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section explains how to customize your application to use other
+Newt Manager protocol options.
+
+Newtmgr Framework Transport Protocol Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The newtmgr framework currently supports BLE and serial transport
+protocols. To configure the transport protocols that are supported,
+modify the ``pkg.yml`` and ``syscfg.yml`` files as follows:
+
+-  Add the ``mgmt/newtmgr/transport/ble`` package to the ``pkg.deps``
+   parameter to enable BLE transport.
+-  Add the ``mgmt/newtmgr/transport/nmgr_shell`` package to the
+   ``pkg.deps`` parameter, and add ``SHELL_TASK: 1`` and
+   ``SHELL_NEWTMGR`` to the ``syscfg.vals`` parameter to enable serial
+   transport when your application also uses the
+   :doc:`Shell </os/modules/shell/shell.md>`__.
+-  Add the ``mgmt/newtmgr/transport/nmgr_uart`` package to the
+   ``pkg.deps`` parameter to enable serial transport over a UART port.
+   You can use this package instead of the ``nmgr_shell`` package when
+   your application does not use the
+   :doc:`Shell </os/modules/shell/shell.md>`__ or you want to use a dedicated
+   UART port to communicate with newtmgr. You can change the
+   ``NMGR_UART`` and ``NMGR_URART_SPEED`` sysconfig values to specify a
+   different port.
+
+Oicmgr Framework Options
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To use the oicmgr framework instead of the newtmgr framework, modify the
+``pkg.yml`` and ``syscfg.yml`` files as follows:
+
+-  Add the ``mgmt/oicmgr`` package (instead of the ``mgmt/newtmgr`` and
+   ``mgmt/newtmgr/transport`` packages as described previously) to the
+   ``pkg.deps`` parameter.
+-  Add ``OC_SERVER: 1`` to the ``syscfg.vals`` parameter.
+
+Oicmgr supports the IP, serial, and BLE transport protocols. To
+configure the transport protocols that are supported, set the
+configuration setting values in the ``syscfg.vals`` parameter as
+follows:
+
+-  Add ``OC_TRANSPORT_IP: 1`` to enable IP transport.
+-  Add ``OC_TRANSPORT_GATT: 1`` to enable BLE transport.
+-  Add ``OC_TRANSPORT_SERIAL: 1``, ``SHELL_TASK: 1``,
+   ``SHELL_NEWTMGR:1`` to enable serial transport.
+
+Customize the Newt Manager Commands that Your Application Supports
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We recommend that you only enable support for the Newt Manager commands
+that your application uses to reduce your application code size. To
+configure the commands that are supported, set the configuration setting
+values in the ``syscfg.vals`` parameter as follows:
+
+-  Add ``LOG_NEWTMGR: 1`` to enable support for the ``newtmgr log``
+   command.
+-  Add ``STATS_NEWTMGR: 1`` to enable support for the ``newtmgr stat``
+   command.
+-  Add ``CONFIG_NEWTMGR: 1`` to enable support for the
+   ``newtmgr config`` command.
+-  Add ``CRASH_TEST_NEWTMGR: 1`` to enable support for the
+   ``newtmgr crash`` command.
+-  Add ``RUNTEST_NEWTMGR: 1`` to enable support for the
+   ``newtmgr crash`` command.
+
+Notes:
+
+-  When you enable Newt Manager support, using either the newtmgr or
+   oicmgr framework, your application automatically supports the Newt
+   Manager ``echo``, ``taskstat``, ``mpstat``, ``datetime``, and
+   ``reset`` commands. These commands cannot be configured individually.
+-  The ``mgmt/imgmgr`` package does not provide a configuration setting
+   to enable or disable support for the ``newtmgr image`` command. Do
+   not specify the package in the ``pkg.deps`` parameter if your device
+   has limited flash memory and cannot support Over-The-Air (OTA)
+   firmware upgrades.

--- a/docs/tutorials/devmgmt/ota_upgrade_nrf52.rst
+++ b/docs/tutorials/devmgmt/ota_upgrade_nrf52.rst
@@ -17,6 +17,10 @@ image management over BLE transport support in your application.
 **Note:** Over-the-air upgrade via newtmgr BLE transport is supported on
 Mac OS and Linux. It is not supported on Windows platforms.
 
+.. contents::
+   :local:
+   :depth: 2
+
 Prerequisites
 -------------
 
@@ -29,15 +33,14 @@ Ensure that you meet the following prerequisites:
 -  Have a Nordic nRF52-DK Development Kit - PCA 10040
 -  Install the :doc:`Segger JLINK software and documentation
    pack <https://www.segger.com/jlink-software.html>`.
--  Install the newt tool and toolchains (See :doc:`Basic
-   Setup </os/get_started/get_started.md>`).
--  Read the Mynewt OS :doc:`Concepts </os/get_started/vocabulary.md>`
+-  Install the newt tool and toolchains (See :doc:`Setup & Get Started <../../get_started/index>`).
+-  Read the Mynewt OS :doc:`Concepts <../../concepts>`
    section.
--  Read the :doc:`Bootloader </os/modules/bootloader/bootloader>`__ section
+-  Read the :doc:`Secure Bootloader <../../../os/modules/bootloader/bootloader>` section
    and understand the Mynewt bootloader concepts.
 -  Build and load the **bleprph** application on to an nRF52-DK board
    via a serial connection. See :doc:`BLE Peripheral
-   App </os/tutorials/bleprph/bleprph-app/>`__.
+   App <../ble/bleprph/bleprph>`.
 
 Reducing the Log Level
 ----------------------
@@ -69,7 +72,7 @@ device over BLE. Step 2: Upload the image to the secondary slot (slot 1)
 on the device. Step 3: Test the image. Step 4: Confirm and make the
 image permanent.
 
-See the :doc:`Bootloader </os/modules/bootloader/bootloader>`__ section for
+See the :doc:`Secure Bootloader <../../../os/modules/bootloader/bootloader>` section for
 more information on the bootloader, image slots, and boot states.
 
 Step 1: Creating a Newtmgr Connection Profile

--- a/docs/tutorials/devmgmt/ota_upgrade_nrf52.rst
+++ b/docs/tutorials/devmgmt/ota_upgrade_nrf52.rst
@@ -1,0 +1,243 @@
+Over-the-Air Image Upgrade
+==========================
+
+Mynewt OS supports over-the-air image upgrades. This tutorial shows you
+how to use the newtmgr tool to upgrade an image on a device over BLE
+communication.
+
+To support over-the-air image upgrade over BLE, a device must be running
+a Mynewt application that has newtmgr image management over BLE
+transport enabled. For this tutorial, we use the
+:doc:`bleprph </os/tutorials/bleprph/bleprph-app/>` application, which
+includes image management over BLE functionality, on an nRF52-DK board.
+If you prefer to use a different BLE application, see :doc:`Enable Newt
+Manager in any app </os/tutorials/add_newtmgr/>` to enable newtmgr
+image management over BLE transport support in your application.
+
+**Note:** Over-the-air upgrade via newtmgr BLE transport is supported on
+Mac OS and Linux. It is not supported on Windows platforms.
+
+Prerequisites
+-------------
+
+Ensure that you meet the following prerequisites:
+
+-  Have Internet connectivity to fetch remote Mynewt components.
+-  Have a computer that supports Bluetooth to communicate with the board
+   and to build a Mynewt application.
+-  Have a Micro-USB cable to connect the board and the computer.
+-  Have a Nordic nRF52-DK Development Kit - PCA 10040
+-  Install the :doc:`Segger JLINK software and documentation
+   pack <https://www.segger.com/jlink-software.html>`.
+-  Install the newt tool and toolchains (See :doc:`Basic
+   Setup </os/get_started/get_started.md>`).
+-  Read the Mynewt OS :doc:`Concepts </os/get_started/vocabulary.md>`
+   section.
+-  Read the :doc:`Bootloader </os/modules/bootloader/bootloader>`__ section
+   and understand the Mynewt bootloader concepts.
+-  Build and load the **bleprph** application on to an nRF52-DK board
+   via a serial connection. See :doc:`BLE Peripheral
+   App </os/tutorials/bleprph/bleprph-app/>`__.
+
+Reducing the Log Level
+----------------------
+
+You need to build your application with log level set to INFO or lower.
+The default log level for the **bleprph** app is set to DEBUG. The extra
+logging causes the communication to timeout. Perform the following to
+reduce the log level to INFO, build, and load the application.
+
+.. code-block:: console
+
+
+   $ newt target amend myperiph syscfg="LOG_LEVEL=1"
+   $ newt build myperiph
+   $ newt create-image myperiph 1.0.0
+   $ newt load myperiph
+
+Upgrading an Image on a Device
+------------------------------
+
+Once you have an application with
+newtmgr image management with BLE transport support running on a device,
+you can use the newtmgr tool to upgrade an image over-the-air.
+
+You must perform the following steps to upgrade an image:
+
+Step 1: Create a newtmgr connection profile to communicate with the
+device over BLE. Step 2: Upload the image to the secondary slot (slot 1)
+on the device. Step 3: Test the image. Step 4: Confirm and make the
+image permanent.
+
+See the :doc:`Bootloader </os/modules/bootloader/bootloader>`__ section for
+more information on the bootloader, image slots, and boot states.
+
+Step 1: Creating a Newtmgr Connection Profile
+--------------------------------------------- 
+
+The **bleprph** application sets and advertises ``nimble-bleprph`` as its bluetooth
+device address. Run the ``newtmgr conn add`` command to create a newtmgr
+connection profile that uses this peer address to communicate with the
+device over BLE:
+
+.. code-block:: console
+
+
+   $ newtmgr conn add mybleprph type=ble connstring="peer_name=nimble-bleprph"
+   Connection profile mybleprph successfully added
+
+Verify that the newtmgr tool can communicate with the device and check
+the image status on the device:
+
+.. code-block:: console
+
+
+   $ newtmgr image list -c mybleprph 
+   Images:
+    slot=0
+       version: 1.0.0
+       bootable: true
+       flags: active confirmed
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+   Split status: N/A (0)
+
+The device only has an image loaded on the primary slot (slot 0). It
+does not have an image loaded on the secondary slot (slot 1). 
+
+Step 2: Uploading an Image to the Device
+----------------------------------------
+
+We create an image with version 2.0.0 for the bleprph application from the ``myperiph`` target and
+upload the new image. You can upload a different image.
+
+.. code-block:: console
+
+   $ newt create-image myperiph 2.0.0
+   App image succesfully generated: ~/dev/myproj/bin/targets/myperiph/app/apps/bleprph/bleprph.img
+
+Run the ``newtmgr image upload`` command to upload the image:
+
+.. code-block:: console
+
+   $ newtmgr image upload -c mybleprph ~/dev/myproj/bin/targets/myperiph/app/apps/bleprph/bleprph.img
+   215
+   429
+   642
+   855
+   1068
+   1281
+
+   ...
+
+   125953
+   126164
+   126375
+   126586
+   126704
+   Done
+
+The numbers indicate the number of bytes that the newtmgr tool has
+uploaded.
+
+Verify that the image uploaded to the secondary slot on the device
+successfully:
+
+.. code-block:: console
+
+
+   $ newtmgr image list -c mybleprph
+   Images:
+    slot=0
+       version: 1.0.0
+       bootable: true
+       flags: active confirmed
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+    slot=1
+       version: 2.0.0
+       bootable: true
+       flags: 
+       hash: 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+   Split status: N/A (0)
+
+The device now has the uploaded image in the secondary slot (slot 1).
+
+Step 3: Testing the Image 
+-------------------------
+
+The image is uploaded to the secondary
+slot but is not yet active. You must run the ``newtmgr image test``
+command to set the image status to **pending** and reboot the device.
+When the device reboots, the bootloader copies this image to the primary
+slot and runs the image.
+
+.. code-block:: console
+
+   $ newtmgr image test -c mybleprph 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+   Images:
+    slot=0
+       version: 1.0.0
+       bootable: true
+       flags: active confirmed
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+    slot=1
+       version: 2.0.0
+       bootable: true
+       flags: pending
+       hash: 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+   Split status: N/A (0)
+
+The status of the image in the secondary slot is now set to **pending**.
+
+Power the device OFF and ON and run the ``newtmgr image list`` command
+to check the image status on the device after the reboot:
+
+.. code-block:: console
+
+
+   $ newtmgr image list -c mybleprph
+   Images:
+    slot=0
+       version: 2.0.0
+       bootable: true
+       flags: active
+       hash: 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+    slot=1
+       version: 1.0.0
+       bootable: true
+       flags: confirmed
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+   Split status: N/A (0)
+
+The uploaded image is now active and running in the primary slot. The
+image, however, is not confirmed. The confirmed image is in the
+secondary slot. On the next reboot, the bootloader reverts to using the
+confirmed image. It copies the confirmed image to the primary slot and
+runs the image when the device reboots. You need to confirm and make the
+uploaded image in the primary slot permanent. 
+
+Step 4: Confirming the Image
+----------------------------
+
+Run the ``newtmgr image confirm`` command to confirm and make the
+uploaded image permanent. Since the uploaded image is currently the
+active image, you can confirm the image setup without specifying the
+image hash value in the command:
+
+.. code-block:: console
+
+   $ newtmgr image confirm -c mybleprph 
+   Images:
+    slot=0
+       version: 2.0.0
+       bootable: true
+       flags: active confirmed
+       hash: 291ebc02a8c345911c96fdf4e7b9015a843697658fd6b5faa0eb257a23e93682
+    slot=1
+       version: 1.0.0
+       bootable: true
+       flags: 
+       hash: b8d17c77a03b37603cd9f89fdcfe0ba726f8ddff6eac63011dee2e959cc316c2
+   Split status: N/A (0)
+
+The uploaded image is now the active and confirmed image. You have
+successfully upgraded an image over-the-air.


### PR DESCRIPTION
Testing blinky with the Arduino Primo resulted in the LED not blinking. The LED_BLINK_PIN was changed from 25 to 20. Changing it back fixed the blinky application. This could be due to an updated version of Primo, though Primo and Primo core are now retired. Left a note in the tutorial in case others run into the same issue.

Also updated FAQ with new FAQs, formatting issues, broken links.