### PR TITLE
drv2605: fix load_rom shell command naming

### DIFF
--- a/docs/tutorials/sensors/sensor_nrf52_drv2605.rst
+++ b/docs/tutorials/sensors/sensor_nrf52_drv2605.rst
@@ -198,8 +198,8 @@ boot if you wanted to use this same sequence every time you trigger the DRV2605 
 .. code-block:: console
 
 
-    120858 compat> drv2605 load 1 255 1 255 1 255 1 255
-    drv2605 load 1 255 1 255 1 255 1 255
+    120858 compat> drv2605 load_rom 1 255 1 255 1 255 1 255
+    drv2605 load_rom 1 255 1 255 1 255 1 255
     122555 Load succeeded
 
 The motor is in standby by default after a mode change, so enable it:


### PR DESCRIPTION
Depends on https://github.com/apache/mynewt-core/pull/1338