### PR TITLE
`newt install` and `newt sync` are deprecated

### DIFF
--- a/docs/get_started/project_create.rst
+++ b/docs/get_started/project_create.rst
@@ -145,7 +145,7 @@ branch may not be stable and you may encounter bugs or other problems.**
 and use the latest master branch. Release 1.0.0 is not supported on
 Windows.
 
-Run the ``newt install`` command, from your project base directory
+Run the ``newt upgrade`` command, from your project base directory
 (myproj), to fetch the source repository and dependencies.
 
 **Note:** It may take a while to download the apache-mynewt-core
@@ -154,8 +154,9 @@ progress.
 
 .. code-block:: console
 
-    $ newt install
-    apache-mynewt-core successfully installed version 1.3.0-none
+    $ newt upgrade
+    Downloading repository mynewt-core (commit: [...])
+    apache-mynewt-core successfully upgraded to version 1.7.0
 
 **Note:** If you get the following error:
 

--- a/docs/mynewt_faq/index.rst
+++ b/docs/mynewt_faq/index.rst
@@ -47,5 +47,5 @@ Version Control Applications with Git
 
 **A**: You can simply have a separate git for your app. For example, if you followed the Blinky tutorial, your git would be in ``apps/foo``, while repos gits are in repos. You may also keep your app in the core repo, just have your own working branch for it. 
 
-Another option is to have your git repository with local packages (including apps) and have ``repository.yml`` there so ``newt install`` can download all dependencies. Just make sure to put e.g. ``bin``, ``repos``, and ``project.state``, and others in ``.gitignore`` so they are not in version control. 
+Another option is to have your git repository with local packages (including apps) and have ``repository.yml`` there so ``newt upgrade`` can download all dependencies. Just make sure to put e.g. ``bin``, ``repos``, and ``project.state``, and others in ``.gitignore`` so they are not in version control. 
 

--- a/docs/mynewt_faq/newt_faq.rst
+++ b/docs/mynewt_faq/newt_faq.rst
@@ -5,16 +5,12 @@ Mynewt FAQ - Newt
   :local:
   :depth: 1
 
-Newt Commands: ``install``, ``upgrade``, ``sync``
+Newt Commands: ``upgrade``, ``install``, ``sync``
 -------------------------------------------------
 
-**Q**: What’s the difference between ``newt install``, ``newt upgrade``, and ``newt sync``?
+**Q**: What’s the difference between ``newt upgrade``, ``newt install``, and ``newt sync``?
 
-**A**: 
-
-- ``newt install``: downloads repos that aren't installed yet.  The downloaded version matches what ``project.yml`` specifies.
-- ``newt upgrade``: performs an install, but also applies to repos that are already installed.
-- ``newt sync``: fetches and pulls the latest for each repo, but does not change the branch (version).
+**A**: Only use ``newt upgrade``.  The other two commands (``install`` and ``sync``) are deprecated and will be removed soon.
 
 ``newt size`` Command vs. Elf File Size
 ---------------------------------------

--- a/docs/tutorials/ble/ble_bare_bones.rst
+++ b/docs/tutorials/ble/ble_bare_bones.rst
@@ -58,13 +58,14 @@ operating system, NimBLE stack, and other system libraries. Later, our
 app may need packages from additional repos, but for now the core repo
 suits our needs.
 
-We download the dependent repos using the ``newt install`` command:
+We download the dependent repos using the ``newt upgrade`` command:
 
 ::
 
     ~/dev$ cd my_proj1
-    ~/dev/my_proj1$ newt install
-    apache-mynewt-core
+    ~/dev/my_proj1$ newt upgrade
+    Downloading repository mynewt-core (commit: [...])
+    apache-mynewt-core successfully upgraded to version 1.7.0
 
 Now it's time to create your own app.
 

--- a/docs/tutorials/ble/blehci_project.rst
+++ b/docs/tutorials/ble/blehci_project.rst
@@ -48,8 +48,9 @@ skeletal Mynewt framework. Change into the newly created directory.
     Project blehciproj  successfully created.
     $ cd mblehciproj 
 
-    $ newt install
-    apache-mynewt-core
+    $ newt upgrade
+    Downloading repository mynewt-core (commit: [...])
+    apache-mynewt-core successfully upgraded to version 1.7.0
 
 Create targets
 ~~~~~~~~~~~~~~

--- a/docs/tutorials/blinky/arduino_zero.rst
+++ b/docs/tutorials/blinky/arduino_zero.rst
@@ -59,8 +59,9 @@ Run the following commands to create a new project:
         Installing skeleton in myproj...
         Project myproj successfully created.
         $ cd myproj
-        $ newt install
-        apache-mynewt-core
+        $ newt upgrade
+        Downloading repository mynewt-core (commit: [...])
+        apache-mynewt-core successfully upgraded to version 1.7.0
         $
 
 Fetch External Packages
@@ -106,22 +107,17 @@ and use the latest master branch for both repositories.
         user: runtimeco
         repo: mynewt_arduino_zero
 
-Install the project dependencies using the ``newt install`` command
+Install the project dependencies using the ``newt upgrade`` command
 (you can specify ``-v`` for verbose output):
 
 .. code-block:: console
 
-    $ newt install
-    apache-mynewt-core
-    mynewt_arduino_zero
+    $ newt upgrade
+    Downloading repository mynewt-core (commit: [...])
+    Downloading repository mynewt_arduino_zero (commit: [...])
+    apache-mynewt-core successfully upgraded to version 1.7.0
+    mynewt_arduino_zero successfully upgraded to version 1.7.0
     $
-
-**NOTE:** If there has been a new release of a repo used in your project
-since you last installed it, the ``1-latest`` version for the repo in
-the ``project.yml`` file will refer to the new release and will not
-match the installed files. In that case you will get an error message
-saying so and you will need to run ``newt upgrade`` to overwrite the
-existing files with the latest codebase.
 
 You need to create two targets for the Arduino Zero Pro board, one
 for the bootloader and one for the Blinky application.

--- a/docs/tutorials/blinky/blinky_primo.rst
+++ b/docs/tutorials/blinky/blinky_primo.rst
@@ -60,8 +60,9 @@ Run the following commands to create a new project:
         Installing skeleton in myproj...
         Project myproj successfully created.
         $ cd myproj
-        $ newt install
-        apache-mynewt-core
+        $ newt upgrade
+        Downloading repository mynewt-core (commit: [...])
+        apache-mynewt-core successfully upgraded to version 1.7.0
         $
 
 Create the Targets

--- a/docs/tutorials/blinky/blinky_stm32f4disc.rst
+++ b/docs/tutorials/blinky/blinky_stm32f4disc.rst
@@ -30,8 +30,9 @@ Run the following commands to create a new project:
         Installing skeleton in myproj...
         Project myproj successfully created.
         $ cd myproj
-        $ newt install
-        apache-mynewt-core
+        $ newt upgrade
+        Downloading repository mynewt-core (commit: [...])
+        apache-mynewt-core successfully upgraded to version 1.7.0
         $
 
 Create the Targets

--- a/docs/tutorials/blinky/nRF52.rst
+++ b/docs/tutorials/blinky/nRF52.rst
@@ -44,8 +44,9 @@ Run the following commands to create a new project:
         Installing skeleton in myproj...
         Project myproj successfully created.
         $ cd myproj
-        $ newt install
-        apache-mynewt-core
+        $ newt upgrade
+        Downloading repository mynewt-core (commit: [...])
+        apache-mynewt-core successfully upgraded to version 1.7.0
         $
 
 Create the Targets

--- a/docs/tutorials/blinky/olimex.rst
+++ b/docs/tutorials/blinky/olimex.rst
@@ -38,8 +38,9 @@ Run the following commands to create a new project:
 
         $ cd myproj
 
-        $ newt install
-        apache-mynewt-core
+        $ newt upgrade
+        Downloading repository mynewt-core (commit: [...])
+        apache-mynewt-core successfully upgraded to version 1.7.0
         $
 
 Create the Targets

--- a/docs/tutorials/blinky/rbnano2.rst
+++ b/docs/tutorials/blinky/rbnano2.rst
@@ -33,8 +33,9 @@ Run the following commands to create a new project:
         Installing skeleton in myproj...
         Project myproj successfully created.
         $ cd myproj
-        $ newt install
-        apache-mynewt-core
+        $ newt upgrade
+        Downloading repository mynewt-core (commit: [...])
+        apache-mynewt-core successfully upgraded to version 1.7.0
         $
 
 Create the Targets

--- a/docs/tutorials/lora/lorawanapp.rst
+++ b/docs/tutorials/lora/lorawanapp.rst
@@ -47,11 +47,9 @@ Now that you have defined the needed repositories, it's time to install everythi
 
 ::
 
-        $ newt install -v 
-        apache-mynewt-core
-        Downloading repository description for apache-mynewt-core... success!
-        ...
-        apache-mynewt-core successfully installed version 1.2.0-none
+        $ newt upgrade -v 
+        Downloading repository mynewt-core (commit: [...])
+        apache-mynewt-core successfully upgraded to version 1.7.0
         ...
 
 Create the targets

--- a/docs/tutorials/other/wi-fi_on_arduino.rst
+++ b/docs/tutorials/other/wi-fi_on_arduino.rst
@@ -57,8 +57,9 @@ Run the following commands to create a new project:
         Installing skeleton in arduinowifi...
         Project arduinowifi successfully created.
         $ cd arduinowifi
-        $ newt install
-        apache-mynewt-core
+        $ newt upgrade
+        Downloading repository mynewt-core (commit: [...])
+        apache-mynewt-core successfully upgraded to version 1.7.0
         $
 
 Fetch External Packages
@@ -117,14 +118,16 @@ and use the latest master branch for both repositories.
         repo: mynewt_arduino_zero 
     $
 
-Install the project dependencies using the ``newt install`` command
+Install the project dependencies using the ``newt upgrade`` command
 (you can specify ``-v`` for verbose output):
 
 .. code-block:: console
 
-    $ newt install
-    apache-mynewt-core
-    mynewt_arduino_zero
+    $ newt upgrade
+    Downloading repository mynewt-core (commit: [...])
+    Downloading repository mynewt_arduino_zero (commit: [...])
+    apache-mynewt-core successfully upgraded to version 1.7.0
+    mynewt_arduino_zero successfully upgraded to version 1.7.0
     $
 
 **NOTE:** If there has been a new release of a repo used in your project

--- a/docs/tutorials/sensors/air_quality_sensor.rst
+++ b/docs/tutorials/sensors/air_quality_sensor.rst
@@ -45,8 +45,11 @@ Your project.yml file should look like this:
             user: apache
             repo: mynewt-core
 
-        [user@IsMyLaptop:~/src/air_quality]$ newt install
-        apache-mynewt-core
+        [user@IsMyLaptop:~/src/air_quality]$ newt upgrade
+        Downloading repository mynewt-core (commit: [...])
+        Downloading repository mynewt-nimble (commit: [...])
+        apache-mynewt-core successfully upgraded to version 0.0.0
+        apache-mynewt-nimble successfully upgraded to version 0.0.0
         [user@IsMyLaptop:~/src/air_quality]$ ls repos/
         apache-mynewt-core
 

--- a/docs/tutorials/sensors/nrf52_adc.rst
+++ b/docs/tutorials/sensors/nrf52_adc.rst
@@ -77,17 +77,13 @@ that you can get started.
 
 .. code-block:: console
 
-    $ newt install -v 
-    apache-mynewt-core
-    Downloading repository mynewt-core (commit: master) ...
-    ....
-    Downloading repository mynewt-nimble (commit: master) ...
-    ....
-    Downloading repository mcuboot (commit: master) ...
-    ....
-    apache-mynewt-core successfully installed version 0.0.0
-    apache-mynewt-nimble successfully installed version 0.0.0
-    mcuboot successfully installed version 0.0.0
+    $ newt upgrade -v 
+    Downloading repository mynewt-core (commit: [...])
+    Downloading repository mynewt-nimble (commit: [...])
+    Downloading repository mcuboot (commit: [...])
+    apache-mynewt-core successfully upgraded to version 1.7.0
+    apache-mynewt-nimble successfully upgraded to version 1.2.0
+    mcuboot successfully upgraded to version 1.3.1
 
 Create the App and Targets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/slinky/project-nrf52-slinky.rst
+++ b/docs/tutorials/slinky/project-nrf52-slinky.rst
@@ -36,8 +36,9 @@ Run the following commands to create a new project. We name the project
     Installing skeleton in slink...
     Project slinky successfully created
     $ cd slinky
-    $newt install
-    apache-mynewt-core
+    $ newt upgrade
+    Downloading repository mynewt-core (commit: [...])
+    apache-mynewt-core successfully upgraded to version 1.7.0
 
 Create the Targets
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/slinky/project-sim-slinky.rst
+++ b/docs/tutorials/slinky/project-sim-slinky.rst
@@ -32,8 +32,9 @@ We will name the project ``slinky``.
     Installing skeleton in slink...
     Project slinky successfully created
     $ cd slinky
-    $newt install
-    apache-mynewt-core
+    $newt upgrade
+    Downloading repository mynewt-core (commit: [...])
+    apache-mynewt-core successfully upgraded to version 1.7.0
 
 Setting up your target build
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/slinky/project-stm32-slinky.rst
+++ b/docs/tutorials/slinky/project-stm32-slinky.rst
@@ -35,8 +35,9 @@ already have a project created or completed the
     Installing skeleton in slink...
     Project slink successfully created
     $ cd slinky
-    $newt install
-    apache-mynewt-core
+    $ newt upgrade
+    Downloading repository mynewt-core (commit: [...])
+    apache-mynewt-core successfully upgraded to version 1.7.0
 
 Create the Targets
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Update docs to use `newt upgrade` exclusively.