### PR TITLE
Fix location of nimble docs - for edit_on_github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,10 @@ _scratch:
 	mkdir _scratch
 	cp -a docs/* _scratch
 	# Copy in docs/ from each of the mynewt-* projects.
-	# NOTE: paths here nead to match edit_on_github in conf.py
+	# NOTE: paths here need to match edit_on_github in conf.py
 	cp -a ../mynewt-core/docs/os _scratch/os
 	#
-	mkdir _scratch/network
-	cp -a ../mynewt-nimble/docs _scratch/network/
+	cp -a ../mynewt-nimble/docs _scratch/network
 	#
 	cp -a ../mynewt-newt/docs _scratch/newt
 	#

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Introduction
    tutorials/tutorials
    external_links
    os/os_user_guide
-   network/docs/index
+   network/index
    newt/index
    newtmgr/index
    mynewt_faq/index


### PR DESCRIPTION
When building the site add Nimble docs under _scratch/network, instead of _scratch/network/docs, which was causing the edit_on_github macro to add and extra `docs` entry to the path. Adjust the toc accordingly.