### PR TITLE
native_install: update macOS "Installing GCC/libc"

### DIFF
--- a/docs/get_started/native_install/native_tools.rst
+++ b/docs/get_started/native_install/native_tools.rst
@@ -24,108 +24,40 @@ pages install it (:doc:`../../newt/install/newt_mac`).
 Installing GCC/libc
 ~~~~~~~~~~~~~~~~~~~
 
-macOS with Xcode ships with a C compiler called Clang. To build applications for the
-Mynewt simulator, a different compiler is used as default: ``gcc``.
+Since macOS with Xcode ships with a C compiler called Clang there is no need to
+install the other compiler. However, one can install gcc compiler with brew:
 
 .. code-block:: console
 
     $ brew install gcc
     ...
     ...
-    ==> Summary
-    🍺  /usr/local/Cellar/gcc/8.2.0 (1,495 files, 335.9MB)
+    ==> Pouring gcc-10.2.0_2.big_sur.bottle.tar.gz
+    🍺  /usr/local/Cellar/gcc/10.2.0_2: 1,455 files, 338.1MB
+
 
 Check the GCC version you have installed (either using ``brew`` or
 previously installed). The brew-installed version can be checked using
-``brew list gcc``. The default compiler.yml configuration file in Mynewt
-expects version 5.x for Mac users, so if the installed version is newer
-and you wish to continue with this newer version, modify the
-``<mynewt-src-directory>/repos/apache-mynewt-core/compiler/sim/compiler.yml``
-file to change the default ``gcc-5`` defined there to that displayed by
-``brew list gcc``, e.g. ``gcc-8``.
-In other words, replace the lines shown highlighted below:
+``brew list gcc``. To use gcc instead of clang ``<mynewt-src-directory>/repos/apache-mynewt-core/compiler/sim/compiler.yml``
+file must be edited:
 
 .. code-block:: yaml
     :emphasize-lines: 2,3
 
     # OS X.
-    compiler.path.cc.DARWIN.OVERWRITE: "gcc-5"
-    compiler.path.as.DARWIN.OVERWRITE: "gcc-5"
+    compiler.path.cc.DARWIN.OVERWRITE: "gcc"
+    compiler.path.as.DARWIN.OVERWRITE: "gcc"
     compiler.path.objdump.DARWIN.OVERWRITE: "gobjdump"
-    compiler.path.objsize.DARWIN.OVERWRITE: "objsize"
     compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"
+    compiler.flags.base.DARWIN: [-DMN_OSX, -Wno-missing-braces]
+    compiler.ld.resolve_circular_deps.DARWIN.OVERWRITE: false
 
 ...with the following:
 
 .. code-block:: yaml
 
-    compiler.path.cc.DARWIN.OVERWRITE: "gcc-8"
-    compiler.path.as.DARWIN.OVERWRITE: "gcc-8”
-
-In case you wish to use Clang, you can change your
-``<mynewt-src-directory>/repos/apache-mynewt-core/compiler/sim/compiler.yml``
-to use Clang. Delete the gcc-5 ``DARWIN.OVERWRITE`` lines highlighted below.
-
-.. code-block:: yaml
-    :emphasize-lines: 2,3
-
-    # OS X.
-    compiler.path.cc.DARWIN.OVERWRITE: "gcc-5"
-    compiler.path.as.DARWIN.OVERWRITE: "gcc-5"
-    compiler.path.objdump.DARWIN.OVERWRITE: "gobjdump"
-    compiler.path.objsize.DARWIN.OVERWRITE: "objsize"
-    compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"
-
-**NOTE:** Both the newer GCC versions and Clang report a few warnings but
-they can be ignored.
-
-**FURTHER NOTE:** Mynewt developers mostly use GCC 5.x for sim builds;
-so it may take a little while to fix issues reported by the newer
-compiler. One option is to **disable warnings**. To do that, remove the
-``-Werror`` flag as an option for the compiler in the
-``<mynewt-src-directory>/repos/apache-mynewt-core/compiler/sim/compiler.yml``
-file as shown below.
-
-.. code-block:: yaml
-    :emphasize-lines: 2
-
-    compiler.flags.base: >
-        -m32 -Wall -ggdb
-
-You may alternatively choose to **specify the precise warnings to
-ignore** depending on the error thrown by the compiler. For example, if
-you see a ``[-Werror=misleading-indentation]`` error while building the
-sim image, add ``-Wno-misleading-indentation]`` as a compiler flag in
-the same line from the
-``<mynewt-src-directory>/repos/apache-mynewt-core/compiler/sim/compiler.yml``
-file.
-
-.. code-block:: yaml
-    :emphasize-lines: 2
-
-    compiler.flags.base: >
-        -m32 -Wall -Werror -ggdb -Wno-misleading-indentation
-
-A third option is to simply **downgrade to GCC 5.x**:
-
-.. code-block:: console
-
-    $ brew install gcc@5
-
-Note that Homebrew will no longer install GCC 5.x on macOS 10.13 and newer:
-
-.. code-block:: console
-
-    $ brew install gcc@5
-    gcc@5: This formula either does not compile or function as expected on macOS
-    versions newer than High Sierra due to an upstream incompatibility.
-    Error: An unsatisfied requirement failed this build.
-
-In this case, you might try downgrading to GCC 6.x, which is still available:
-
-.. code-block:: console
-
-    $ brew install gcc@6
+    compiler.path.cc.DARWIN.OVERWRITE: "gcc-<version>"
+    compiler.path.as.DARWIN.OVERWRITE: "gcc-<version>”
 
 Installing GDB
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Mynewt Core accommodated clang as default compiler for macOS systems,
as gcc-5 was old and not supported on newer macOS versions. Still, gcc
might be installed and used, but it's no longer a default solution.