### PR TITLE
native_install: Update link to toolchain for Windows

### DIFF
--- a/docs/get_started/native_install/cross_tools.rst
+++ b/docs/get_started/native_install/cross_tools.rst
@@ -64,9 +64,9 @@ https://launchpad.net/~team-gcc-arm-embedded/+archive/ubuntu/ppa.
 Installing the ARM Toolchain for Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#.  Download and run the `installer <https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-win32.exe>`__
+#.  Download and run the `installer <https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-win32.exec>`__
     to install arm-none-eabi-gcc and arm-none-eabi-gdb. Select the default
-    destination folder: **C:\\Program Files (x86)\\GNU Tools ARM Embedded\\8 2018-q4-major**.
+    destination folder: **C:\\Program Files (x86)\\GNU Arm Embedded Toolchain\\10 2020-q4-major**.
 
     **Notes:**
 
@@ -84,9 +84,9 @@ Installing the ARM Toolchain for Windows
     .. code-block:: console
 
         $ which arm-none-eabi-gcc
-        /c/Program Files (x86)/GNU Tools ARM Embedded/8 2018-q4-major/bin/arm-none-eabi-gcc
-        $which arm-none-eabi-gdb
-        /c/Program Files (x86)/GNU Tools ARM Embedded/8 2018-q4-major/bin/arm-none-eabi-gdb
+        /c/Program Files (x86)/GNU Arm Embedded Toolchain/10 2020-q4-major/bin/arm-none-eabi-gcc
+        $ which arm-none-eabi-gdb
+        /c/Program Files (x86)/GNU Arm Embedded Toolchain/10 2020-q4-major/bin/arm-none-eabi-gdb
 
 Installing the Debuggers
 ------------------------


### PR DESCRIPTION
This fixes error that occurred on Windows at newt create-image command:
Error: arm-none-eabi-objcopy
[..]pache-mynewt-nimble/apps/bttester/bttester.hex 64-bit address
0x4b4fa30000c000 out of range for Intel Hex file