### PR TITLE
Fix search for Sphinx>=1.8.0

### DIFF
--- a/docs/themes/mynewt/layout.html
+++ b/docs/themes/mynewt/layout.html
@@ -155,7 +155,8 @@ ga("send", "pageview");
             COLLAPSE_INDEX:false,
             FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
             HAS_SOURCE:  {{ has_source|lower }},
-            SOURCELINK_SUFFIX: '.txt'
+            SOURCELINK_SUFFIX: '.txt',
+            LINK_SUFFIX: '.html'
         };
     </script>
     {%- for scriptfile in script_files %}

--- a/docs/themes/mynewt/search.html
+++ b/docs/themes/mynewt/search.html
@@ -10,6 +10,7 @@
 {%- extends "layout.html" %}
 {% set title = _('Search') %}
 {% set script_files = script_files + ['_static/searchtools.js'] %}
+{% set script_files = script_files + ['_static/language_data.js'] %}
 {% block footer %}
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });


### PR DESCRIPTION
This should fix searching documentation for Mynewt versions 1.4.0 and up.

* Add missing JS file with Stemmer definition, which is auto-generated for Sphinx>=1.8.0.
* Add configuration for page extension.