### PR TITLE
docs/conf: Disable `google_analytics` in Sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ html_theme_path = ['./themes']
 # documentation.
 #
 html_theme_options = {
-    'google_analytics': ('UA-72162311-1', 'auto')
+    'google_analytics': False
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Removes Google Analytics from the documentation site to align with [ASF Data Privacy Policy.](https://privacy.apache.org/faq/committers.html)