### PR TITLE
documentation: add `master` as a selectable version

### DIFF
--- a/docs/themes/mynewt/layout.html
+++ b/docs/themes/mynewt/layout.html
@@ -115,7 +115,17 @@ ga("send", "pageview");
             {% include "sidebar.html" %}
 
             <div class="col-xs-12 col-sm-9">
-              {% if cur_version != latest_version %}
+
+              {% if cur_version == "master" %}
+                <div class="alert alert-warning">
+                  <p>
+                    Version {{ cur_version }} is the development version of the
+                    Apache Mynewt documentation. Click <a href="/latest">here</a> to
+                    read the latest released version.
+                  </p>
+                </div>
+
+              {% elif cur_version != latest_version %}
                 <div class="alert alert-warning">
                   <p>
                     Version {{ cur_version }} is not the most recent version of the

--- a/docs/themes/mynewt/versions.html
+++ b/docs/themes/mynewt/versions.html
@@ -3,7 +3,10 @@
   <option value="/latest" selected>
     Version: latest
   </option>
-  <option value="/v1_12_0" {% if cur_version == "1.12.0" %}selected="selected" {% endif %}>
+  <option value="/master" {% if cur_version == "master" %}selected="selected" {% endif %}>
+    Version: master
+  </option>
+ <option value="/v1_12_0" {% if cur_version == "1.12.0" %}selected="selected" {% endif %}>
     Version: 1.12.0
   </option>
   <option value="/v1_11_0" {% if cur_version == "1.11.0" %}selected="selected" {% endif %}>


### PR DESCRIPTION
Adds the master branch documentation as an option to choose from the drop-down list in the `Documentation` section.