### PR TITLE
Fix styles tag in layout.html

### DIFF
--- a/docs/themes/mynewt/layout.html
+++ b/docs/themes/mynewt/layout.html
@@ -35,7 +35,7 @@
 
     {# CSS #}
 
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/' + styles[-1], 1) }}" type="text/css" />
 
     {% for cssfile in css_files %}
       <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />


### PR DESCRIPTION
This change is required to upgrade Sphinx to 8. version. Deprecated tag caused an error when runninng build.py